### PR TITLE
Update on wget command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ to prepare a dish that incorporates a basket of mystery ingredients.
 To get mystery installed quickly, run this:
 
 ```
-curl install.sh - https://raw.githubusercontent.com/asilvr/mystery/main/install.sh -o install.sh > /dev/null 2>&1; chmod +x install.sh; ./install.sh;
+curl https://raw.githubusercontent.com/asilvr/mystery/main/install.sh -o install.sh > /dev/null 2>&1; chmod +x install.sh; ./install.sh;
 ```
 Or, you can download the latest version of the `mystery` CLI tool in the 
 [releases](https://github.com/asilvr/mystery/releases) section. The tool is 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ to prepare a dish that incorporates a basket of mystery ingredients.
 
 ## Download
 To get mystery installed quickly, run this:
+
 ```
- wget -O install.sh - https://raw.githubusercontent.com/asilvr/mystery/main/install.sh > /dev/null 2>&1; chmod +x install.sh; ./install.sh;
+curl install.sh - https://raw.githubusercontent.com/asilvr/mystery/main/install.sh -o install.sh > /dev/null 2>&1; chmod +x install.sh; ./install.sh;
 ```
 Or, you can download the latest version of the `mystery` CLI tool in the 
 [releases](https://github.com/asilvr/mystery/releases) section. The tool is 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ to prepare a dish that incorporates a basket of mystery ingredients.
 To get mystery installed quickly, run this:
 
 ```
-url -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/asilvr/mystery/main/install.sh -o install.sh > /dev/null 2>&1; chmod +x install.sh; sudo ./install.sh;
+curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/asilvr/mystery/main/install.sh -o install.sh > /dev/null 2>&1; chmod +x install.sh; sudo ./install.sh;
 ```
 Or, you can download the latest version of the `mystery` CLI tool in the 
 [releases](https://github.com/asilvr/mystery/releases) section. The tool is 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ to prepare a dish that incorporates a basket of mystery ingredients.
 To get mystery installed quickly, run this:
 
 ```
-curl https://raw.githubusercontent.com/asilvr/mystery/main/install.sh -o install.sh > /dev/null 2>&1; chmod +x install.sh; ./install.sh;
+url -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/asilvr/mystery/main/install.sh -o install.sh > /dev/null 2>&1; chmod +x install.sh; sudo ./install.sh;
 ```
 Or, you can download the latest version of the `mystery` CLI tool in the 
 [releases](https://github.com/asilvr/mystery/releases) section. The tool is 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ to prepare a dish that incorporates a basket of mystery ingredients.
 ## Download
 To get mystery installed quickly, run this:
 ```
-wget -O - https://github.com/asilvr/mystery/blob/main/install.sh | bash
+ wget -O install.sh - https://raw.githubusercontent.com/asilvr/mystery/main/install.sh > /dev/null 2>&1; chmod +x install.sh; ./install.sh;
 ```
 Or, you can download the latest version of the `mystery` CLI tool in the 
 [releases](https://github.com/asilvr/mystery/releases) section. The tool is 


### PR DESCRIPTION
Previous wget command couldn't work because it wasn't getting raw script data. This has been changed, also `install.sh` is now automatically executable with `chmod +x ` support.